### PR TITLE
feat: Add deploy by serverless with serverless-next.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,16 +3,19 @@
 
 # production
 build
-.serverless
 
 # build
 
 **/.next/
+.serverless
+.serverless_nextjs
+packages/client-web/out
 
 # misc
 .DS_Store
 /.idea
 .vscode
+node_modules
 
 *.log
 

--- a/.pnp.js
+++ b/.pnp.js
@@ -90,6 +90,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@material-ui/icons", "virtual:0f6b7972d7283ebbae009c999090c56aae1c5722aa8f1c15856a00dd562334187914ebb64811a3f51bdd8d2f109239075c5f99a56050f0917223d61d77b343e8#npm:4.11.2"],
             ["@material-ui/styles", "virtual:0f6b7972d7283ebbae009c999090c56aae1c5722aa8f1c15856a00dd562334187914ebb64811a3f51bdd8d2f109239075c5f99a56050f0917223d61d77b343e8#npm:4.11.3"],
             ["@next/bundle-analyzer", "npm:10.0.9"],
+            ["@next/env", "npm:10.0.9"],
             ["@types/node", "npm:14.14.37"],
             ["@types/ramda", "https://github.com/types/npm-ramda.git#commit=9529aa3c8ff70ff84afcbc0be83443c00f30ea90"],
             ["@types/react", "npm:17.0.3"],

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+# Packages
 
-## Available Scripts
+## [client-web](./packages/client-web)
 
-In the project directory, you can run:  
-You can use NPM instead of YARN (Up to you)  
+NextJS Front end application.
+Available commands:
 
-### `yarn start` OR `npm run start`
+### `yarn dev`
 
 Runs the app in the development mode.<br />
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
@@ -13,33 +13,27 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 The page will reload if you make edits.<br />
 You will also see any lint errors in the console.
 
-### `yarn test` OR `npm run test`
+### `yarn deploy`
 
-Launches the test runner in the interactive watch mode.<br />
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+Runs build + deploy to AWS via serverless.
 
-### `yarn build` OR `npm run build`
+Application will be available at [https://dyth48evx2jw.cloudfront.net](https://dyth48evx2jw.cloudfront.net)
 
-Builds the app for production to the `build` folder.<br />
-It correctly bundles React in production mode and optimizes the build for the best performance.
+### `yarn cleanup`
 
-The build is minified and the filenames include the hashes.<br />
-Your app is ready to be deployed!
+Deletes all build/deploy folders
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+## Global Scripts
 
-### `yarn eject` OR `npm run eject`
+In the project directory, you can run:
+(You should use Yarn)
 
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
+### `yarn dev`
 
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+Alias for `yarn workspace @app/client-web dev`.
+Runs frontend dev server.
 
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+### `yarn deploy`
 
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
+Alias for `yarn workspace @app/client-web deploy`.
+Deploy with serverless.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "scripts": {
     "dev": "yarn workspace @app/client-web dev",
     "build": "yarn workspace @app/client-web build",
+    "deploy": "yarn workspace @app/client-web deploy",
     "cleanup": "yarn workspace @app/client-web cleanup",
     "lint": "eslint {packages,libs}/**/*.{ts,tsx}",
     "test": "jest --maxWorkers=1",

--- a/packages/client-web/next.config.js
+++ b/packages/client-web/next.config.js
@@ -25,6 +25,7 @@ module.exports = withPlugins(
     })
   ],
   {
+    target: 'serverless',
     reactStrictMode: configuration.build.react.enableStrictMode,
     /**
      * @see https://nextjs.org/docs/api-reference/next.config.js/configuring-onDemandEntries

--- a/packages/client-web/package.json
+++ b/packages/client-web/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@lib/next-transpile-pnp-workspace": "workspace:*",
     "@next/bundle-analyzer": "^10.0.9",
+    "@next/env": "^10.0.9",
     "@types/node": "^14.14.37",
     "@types/ramda": "https://github.com/types/npm-ramda.git#commit=9529aa3c8ff70ff84afcbc0be83443c00f30ea90",
     "@types/react": "^17.0.3",
@@ -30,7 +31,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "cleanup": "yarn dlx rimraf .next",
+    "deploy": "yarn dlx serverless",
+    "cleanup": "yarn dlx rimraf .next .serverless .serverless_nextjs",
     "analyze": "yarn analyze:typescript",
     "analyze:typescript": "tsc --noEmit -p tsconfig.json"
   }

--- a/packages/client-web/serverless.yaml
+++ b/packages/client-web/serverless.yaml
@@ -1,0 +1,9 @@
+client-web:
+  component: "@sls-next/serverless-component@1.18.0"
+  inputs:
+    build:
+      cmd: yarn
+      args:
+        - workspace
+        - "@app/client-web"
+        - build

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,7 @@ __metadata:
     "@material-ui/icons": ^4.11.2
     "@material-ui/styles": ^4.11.3
     "@next/bundle-analyzer": ^10.0.9
+    "@next/env": ^10.0.9
     "@types/node": ^14.14.37
     "@types/ramda": "https://github.com/types/npm-ramda.git#commit=9529aa3c8ff70ff84afcbc0be83443c00f30ea90"
     "@types/react": ^17.0.3
@@ -1010,7 +1011,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:10.0.9":
+"@next/env@npm:10.0.9, @next/env@npm:^10.0.9":
   version: 10.0.9
   resolution: "@next/env@npm:10.0.9"
   checksum: a41735627f35db20f4a3804c6caa22edd01f3cfdf071e0e70ddec2007c42cc5987cbad9c5f7bd9a9410e721b60b0719f958a764f25864ce61b2684a714d981e0


### PR DESCRIPTION
CloudFront: https://dyth48evx2jw.cloudfront.net
Не окончательное решение, т.к. надо сделать через next build + next export + обычный деплой SPA.
Решение через serverless-компонент для некста (https://github.com/serverless-nextjs/serverless-next.js) содержит слишком много магии.